### PR TITLE
feat: basic credentials support for maven repos

### DIFF
--- a/buildGradleApplication/default.nix
+++ b/buildGradleApplication/default.nix
@@ -15,13 +15,14 @@
   buildInputs ? [],
   nativeBuildInputs ? [],
   dependencyFilter ? depSpec: true,
+  privateRepository ? null,
   repositories ? ["https://plugins.gradle.org/m2/" "https://repo1.maven.org/maven2/"],
   verificationFile ? "gradle/verification-metadata.xml",
   buildTask ? ":installDist",
   installLocation ? "build/install/*/",
 }: let
   m2Repository = mkM2Repository {
-    inherit pname version src dependencyFilter repositories verificationFile;
+    inherit pname version src dependencyFilter privateRepository repositories verificationFile;
   };
 
   # Prepare a script that will replace that jars with references into the NIX store.

--- a/fetchArtefact/default.nix
+++ b/fetchArtefact/default.nix
@@ -4,6 +4,7 @@
   nix,
   cacert,
 }: {
+  privateUrl ? null,
   # A list of URLs specifying alternative download locations. They are tried in order.
   urls,
   # SRI hash.
@@ -19,7 +20,9 @@ stdenvNoCC.mkDerivation {
   builder = ./builder.bash;
   nativeBuildInputs = [curl nix];
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  private_url = privateUrl;
   inherit urls;
+  impureEnvVars = ["NIX_CURL_FLAGS"];
 
   # Doing the download on a remote machine just duplicates network
   # traffic, so don't do that


### PR DESCRIPTION
This adds basic credentials support for accessing maven repositories.

There is currently no mechanism to distinguish between private and public repositories. If specified, it unconditionally adds the authorization header as bearer token value to the request when fetching the artifacts. Another limitation is, that currently only a bearer token is supported and not e.g. basic auth using username and password.

This seems to be working, as long as the package is being built with elevated privileges, e.g.:

```
# AUTH_TOKEN=hunter2 nix build
```

This closes #8.

Please, let me know what you think.

