### PR TITLE
Make it possible to wrapGApps without 4x wrapping

### DIFF
--- a/buildGradleApplication/default.nix
+++ b/buildGradleApplication/default.nix
@@ -65,7 +65,7 @@ let
     done
   '';
 
-  package = lib.makeOverridable stdenvNoCC.mkDerivation ((cleanAttrs attrs) // {
+  package = stdenvNoCC.mkDerivation ((cleanAttrs attrs) // {
     inherit pname version src meta buildInputs;
     nativeBuildInputs = [gradle jdk makeWrapper] ++ nativeBuildInputs;
     buildPhase = ''

--- a/buildGradleApplication/default.nix
+++ b/buildGradleApplication/default.nix
@@ -5,12 +5,7 @@
   writeShellScript,
   makeWrapper,
   mkM2Repository,
-}:
-let
-  cleanAttrs = lib.flip removeAttrs [
-    "pname" "version" "src" "meta" "jdk" "gradle" "buildInputs" "nativeBuildInputs" "dependencyFilter" "repositories" "verificationFile" "buildTask" "installLocation" "dontWrapGApps"
-  ];
-in {
+}: {
   pname,
   version,
   src,
@@ -24,9 +19,7 @@ in {
   verificationFile ? "gradle/verification-metadata.xml",
   buildTask ? ":installDist",
   installLocation ? "build/install/*/",
-  ...
-} @ attrs:
-let
+}: let
   m2Repository = mkM2Repository {
     inherit pname version src dependencyFilter repositories verificationFile;
   };
@@ -65,7 +58,7 @@ let
     done
   '';
 
-  package = stdenvNoCC.mkDerivation ((cleanAttrs attrs) // {
+  package = stdenvNoCC.mkDerivation {
     inherit pname version src meta buildInputs;
     nativeBuildInputs = [gradle jdk makeWrapper] ++ nativeBuildInputs;
     buildPhase = ''
@@ -116,6 +109,6 @@ let
         --set-default JAVA_HOME "${jdk.home}" \
         ''${gappsWrapperArgs[@]}
     '';
-  });
+  };
 in
   package


### PR DESCRIPTION
Also allows for more customization in the mkDerivation

This is a follow-up pr to #19 for implementing https://github.com/Col-E/Recaf/pull/805

4x wrapping, because wrapGApps will wrap the original script and then the wrapper, which sets JavaHome.

I let myself be inspired by how nixos's buildPythonApplication/mkPythonDerivation works. 

Also sadly it was nessesary for me to statically set `dontWrapGApps=true`.
That itself should not be an issue, since the `gappsWrapperArgs` do get applied as they should in `postFixup`.

Please note, that this change does not make it required to use `wrapGAppsHook`. It just makes it, so that everything works as best as possible, when it's specified.