### PR TITLE
Replace `--console=plain` gradle flag

### DIFF
--- a/buildGradleApplication/default.nix
+++ b/buildGradleApplication/default.nix
@@ -75,7 +75,7 @@
       export APP_VERSION=${version}
 
       # built the dam thing!
-      gradle --offline --no-daemon --no-watch-fs --no-configuration-cache --no-build-cache --console=plain --no-scan -Porg.gradle.java.installations.auto-download=false --init-script ${./init.gradle.kts} ${buildTask}
+      gradle --offline --no-daemon --no-watch-fs --no-configuration-cache --no-build-cache -Dorg.gradle.console=plain --no-scan -Porg.gradle.java.installations.auto-download=false --init-script ${./init.gradle.kts} ${buildTask}
 
       runHook postBuild
     '';


### PR DESCRIPTION
gradleSetupHook now includes `--console plain`: https://github.com/NixOS/nixpkgs/commit/c12b2a0b196a42a20949cf648c86acfbe6418ad3#diff-05edf78db91e194716431e8387e022e3734cf39e3ecfb550373fe9378ffa51ecR7

Gradle errors when the same flag is passed twice: https://github.com/gradle/gradle/issues/30913

Although maybe it should only be dropped if it's already present in `gradleFlagsArray`? 